### PR TITLE
added new function to check email size limit on host

### DIFF
--- a/mail/Makefile.am
+++ b/mail/Makefile.am
@@ -44,7 +44,7 @@ cmail_la_SOURCES    = \
 	imap_utility.h \
 	tingeling.c
 cmail_la_LDFLAGS    = -no-undefined -module -avoid-version
-cmail_la_LIBADD     = -lc-client -lcrypto @gss@
+cmail_la_LIBADD     = -lc-client -lssl -lcrypto @gss@
 
 cmail_core.c: @MODULE_SRC_PREFIX@/mail/cmail.fec
 	@BUILDER@ -m cmail @MODULE_SRC_PREFIX@/mail/cmail.fec

--- a/mail/cmail.fec
+++ b/mail/cmail.fec
@@ -722,6 +722,37 @@ namespace modifies Mail {
 		    }
 		    FE_RETURN_FALSE;
 		}
+
+		function setupSSLCert(string &_server, string username, string password, boolean ssl){
+			_server = _server + (ssl ? "/ssl/novalidate-cert" : "/novalidate-cert/notls") + (username ? "/authuser=$username" : "");
+		}
+
+        native function getServerMaxMailSize(string server ) {
+            SENDSTREAM *stream = NULL;
+            NETMBX networkMailbox;
+            char *hostlist[] = { server->data, NIL };
+            long maxMailSize = -1;
+
+			memset(&networkMailbox, '\0', sizeof(networkMailbox));
+			stream = smtp_open( hostlist, FE_FALSE); 
+            if( stream == NULL ) {
+                set_error_string( script, self,"Error opening SMTP stream" );
+                FE_RETURN_LONG( -2 );
+            }
+
+            smtp_ehlo( stream, "localhost", &networkMailbox );
+
+            if(stream->protocol.esmtp.size.ok){
+                maxMailSize = stream->protocol.esmtp.size.limit;
+            }
+			else{
+				maxMailSize = -3;
+			}
+
+            smtp_close( stream );
+
+            FE_RETURN_LONG( maxMailSize );
+        }
 	}
 	/**
 	 * @end


### PR DESCRIPTION
added getServerMaxMailSize() to cmail.fec to retrieve the email size limit from stream->protocol.esmtp.size.limit where stream is 
SENDSTREAM *stream

made changes to Makefile.am to get rid of dynamic loader ssl error when running with cmail.so
