### PR TITLE
Fix for .mov file attachment bug

### DIFF
--- a/mail/imap_utility.c
+++ b/mail/imap_utility.c
@@ -285,7 +285,7 @@ FeriteVariable *create_ferite_content_object( FeriteScript *script, MAILSTREAM *
 					ptr = ptr->next;
 				}
 			}
-			v = fe_new_str("content", buf2, len2, FE_CHARSET_DEFAULT );
+			v = fe_new_bin_str("content", buf2, len2, FE_CHARSET_DEFAULT );
 			ferite_object_set_var(script, VAO(object), "content", v );
 
 			v = fe_new_lng("encoding", body->encoding );


### PR DESCRIPTION
Quicktime .mov files start with "\0\0\0". Therefore the older ferite_new_str function
cannot differentiate between binary data blobs that start with NUL and an empty string.
The fix is to modify Ferite to include a binary safe ferite_new_bin_str feature to
properly handle binary blobs. But this requires the newer modified Ferite with the
included function.
